### PR TITLE
fix: Spring AI 1.1.2 extra_body 직렬화 버그 workaround

### DIFF
--- a/shared/src/main/java/com/jaeyeonling/shared/OpenAiExtraBodyWorkaround.java
+++ b/shared/src/main/java/com/jaeyeonling/shared/OpenAiExtraBodyWorkaround.java
@@ -1,0 +1,54 @@
+package com.jaeyeonling.shared;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.web.client.RestClientCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Spring AI 1.1.x의 extra_body 직렬화 버그 workaround.
+ *
+ * <h3>문제</h3>
+ * Spring AI 1.1.0에서 {@code ChatCompletionRequest}의 {@code extraBody} 필드가
+ * null일 때 빈 HashMap으로 초기화되도록 변경되었고, 1.1.1에서 {@code @JsonProperty("extra_body")}
+ * 어노테이션이 추가되면서 빈 {@code "extra_body": {}}가 모든 Chat Completion 요청에
+ * 직렬화됩니다. OpenAI API는 인식하지 못하는 파라미터를 거부하므로 HTTP 400 에러가 발생합니다.
+ *
+ * <h3>해결</h3>
+ * {@link RestClientCustomizer}로 나가는 HTTP 요청의 JSON body에서
+ * {@code extra_body} 키를 제거합니다.
+ *
+ * <h3>제거 시점</h3>
+ * Spring AI 1.1.3 또는 2.0.0 GA 릴리스 시 이 클래스를 제거하세요.
+ *
+ * @see <a href="https://github.com/spring-projects/spring-ai/issues/5196">spring-ai#5196</a>
+ * @see <a href="https://github.com/jaeyeonling/spring-ai-bootcamp/issues/1">bootcamp#1</a>
+ */
+@Configuration
+@ConditionalOnClass(name = "org.springframework.ai.openai.api.OpenAiApi")
+public class OpenAiExtraBodyWorkaround {
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+    @Bean
+    public RestClientCustomizer openAiExtraBodyStripper(final ObjectMapper objectMapper) {
+        return builder -> builder.requestInterceptor((request, body, execution) -> {
+            if (body.length > 0) {
+                try {
+                    final Map<String, Object> map = objectMapper.readValue(body, MAP_TYPE);
+                    if (map.remove("extra_body") != null) {
+                        body = objectMapper.writeValueAsBytes(map);
+                    }
+                } catch (final IOException ignored) {
+                    // JSON이 아닌 요청(파일 업로드 등)은 원본 그대로 전달
+                }
+            }
+            return execution.execute(request, body);
+        });
+    }
+}

--- a/shared/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/shared/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.jaeyeonling.shared.OpenAiExtraBodyWorkaround


### PR DESCRIPTION
## Summary

- Spring AI 1.1.x의 `ChatCompletionRequest`가 빈 `extra_body: {}`를 항상 직렬화하여 OpenAI Chat Completion API에서 HTTP 400 발생하는 문제를 `RestClientCustomizer`로 해결
- `shared` 모듈에 Spring Boot 자동설정으로 등록하여 전 주차 모듈에 자동 적용

## 변경 파일

| 파일 | 설명 |
|------|------|
| `shared/.../OpenAiExtraBodyWorkaround.java` | `RestClientCustomizer` 빈 — JSON body에서 `extra_body` 키 제거 |
| `shared/.../AutoConfiguration.imports` | Spring Boot 자동설정 등록 |

## 원인 분석

| 버전 | 커밋 | 변경 |
|------|------|------|
| v1.1.0 | [3fc939a](https://github.com/spring-projects/spring-ai/commit/3fc939a) | `extraBody` null → 빈 HashMap 초기화 |
| v1.1.1 | [0646d1e](https://github.com/spring-projects/spring-ai/commit/0646d1e) | `@JsonProperty("extra_body")` 추가 → 직렬화 시작 |

`@JsonInclude(NON_NULL)`이 적용되어 있지만 빈 맵은 null이 아니므로 제외되지 않음.

## 검증

- v2.0.0-M2 소스코드 직접 확인 — 동일 버그 존재 (업그레이드로 해결 불가)
- main 브랜치에서는 `extraBody` 필드 완전 제거됨 — 릴리스 미반영
- workaround 적용 후 통합 테스트 10개 전체 통과 확인

## 제거 시점

Spring AI 1.1.3 또는 2.0.0 GA 릴리스 시 이 workaround를 제거.

## References

- Closes #1
- [spring-ai#5196](https://github.com/spring-projects/spring-ai/issues/5196)
- [spring-ai#5321](https://github.com/spring-projects/spring-ai/pull/5321)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an auto-configuration workaround to improve compatibility with Spring AI 1.1.x and ensure proper handling of outbound requests. This workaround is temporary and planned for removal in future versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->